### PR TITLE
fix(license): 收紧本地授权降级逻辑

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -180,7 +180,7 @@ export default class StandaloneEpubPlugin extends Plugin implements EpubHostCapa
 	}
 
 	hasEpubPremiumAccess(): boolean {
-		return this.getEffectiveLicenseState().isPremiumActive;
+		return PremiumFeatureGuard.getInstance().getEffectiveState().isPremiumActive;
 	}
 
 	openEpubPremiumSettings(): void {

--- a/src/utils/__tests__/license-manager-validation.test.ts
+++ b/src/utils/__tests__/license-manager-validation.test.ts
@@ -77,4 +77,19 @@ describe("LicenseManager current license validation", () => {
 		expect(result.isValid).toBe(true);
 		expect(cloudValidator.validate).toHaveBeenCalledTimes(1);
 	});
+
+	it("downgrades when initial cloud validation is unavailable", async () => {
+		const { manager, cloudValidator } = createManager();
+		cloudValidator.validate.mockResolvedValue({
+			valid: false,
+			is_network_error: true,
+		});
+
+		const result = await manager.validateCurrentLicense(buildLicense());
+
+		expect(result).toMatchObject({
+			isValid: false,
+			error: "许可证验证暂时不可用，请恢复网络后重试",
+		});
+	});
 });

--- a/src/utils/__tests__/license-manager-validation.test.ts
+++ b/src/utils/__tests__/license-manager-validation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { LicenseManager } from "../licenseManager";
+import type { LicenseInfo } from "../../types/license";
+
+function buildLicense(overrides: Partial<LicenseInfo> = {}): LicenseInfo {
+	return {
+		activationCode: "signed-code",
+		isActivated: true,
+		activatedAt: "2026-04-01T00:00:00.000Z",
+		deviceFingerprint: "device",
+		expiresAt: "2099-04-01T00:00:00.000Z",
+		productVersion: "0.7.20",
+		licenseType: "lifetime",
+		boundEmail: "owner@example.com",
+		issuedProductId: "weave-epub-reader",
+		entitlements: ["epub-premium"],
+		...overrides,
+	};
+}
+
+function createManager() {
+	const manager = new LicenseManager();
+	const cloudValidator = {
+		setApp: vi.fn(),
+		validate: vi.fn(),
+		clearCache: vi.fn(),
+	};
+	(manager as any).cloudValidator = cloudValidator;
+	vi.spyOn(manager as any, "generateDeviceFingerprint").mockResolvedValue("device");
+	const validateActivationCode = vi
+		.spyOn(manager, "validateActivationCode")
+		.mockResolvedValue({ isValid: true });
+
+	return { manager, cloudValidator, validateActivationCode };
+}
+
+describe("LicenseManager current license validation", () => {
+	it("keeps inactive records free without parsing an activation code or calling cloud validation", async () => {
+		const { manager, cloudValidator, validateActivationCode } = createManager();
+
+		const result = await manager.validateCurrentLicense(
+			buildLicense({ isActivated: false, activationCode: "", boundEmail: undefined })
+		);
+
+		expect(result).toMatchObject({ isValid: false, error: "许可证未激活" });
+		expect(validateActivationCode).not.toHaveBeenCalled();
+		expect(cloudValidator.validate).not.toHaveBeenCalled();
+	});
+
+	it("downgrades activated records that lack a bound email", async () => {
+		const { manager, cloudValidator } = createManager();
+
+		const result = await manager.validateCurrentLicense(buildLicense({ boundEmail: undefined }));
+
+		expect(result).toMatchObject({
+			isValid: false,
+			error: "许可证缺少绑定邮箱，请重新激活",
+		});
+		expect(cloudValidator.validate).not.toHaveBeenCalled();
+	});
+
+	it("forces cloud validation for an activated record after manager initialization", async () => {
+		const { manager, cloudValidator } = createManager();
+		cloudValidator.validate.mockResolvedValue({ valid: true });
+
+		const persistedAt = new Date().toISOString();
+		const result = await manager.validateCurrentLicense(
+			buildLicense({
+				cloudSync: {
+					status: "synced",
+					syncedAt: persistedAt,
+					lastValidatedAt: persistedAt,
+				},
+			})
+		);
+
+		expect(result.isValid).toBe(true);
+		expect(cloudValidator.validate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/__tests__/license-validation-lease.test.ts
+++ b/src/utils/__tests__/license-validation-lease.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { CloudValidationLease } from "../license-validation-lease";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse("2026-04-10T12:00:00.000Z");
+
+describe("CloudValidationLease", () => {
+	it("starts invalid and requires validation", () => {
+		expect(new CloudValidationLease().getStatus(NOW)).toEqual({
+			valid: false,
+			needsValidation: true,
+		});
+	});
+
+	it("accepts only a success recorded in the current process", () => {
+		const lease = new CloudValidationLease();
+		lease.recordSuccess(NOW - DAY_MS);
+
+		expect(lease.getStatus(NOW)).toEqual({ valid: true, needsValidation: false });
+	});
+
+	it("requires validation after it expires", () => {
+		const lease = new CloudValidationLease();
+		lease.recordSuccess(NOW - 8 * DAY_MS);
+
+		expect(lease.getStatus(NOW)).toEqual({ valid: false, needsValidation: true });
+	});
+
+	it("clears on a new plugin initialization", () => {
+		const lease = new CloudValidationLease();
+		lease.recordSuccess(NOW);
+		lease.clear();
+
+		expect(lease.getStatus(NOW)).toEqual({ valid: false, needsValidation: true });
+	});
+});

--- a/src/utils/license-validation-lease.ts
+++ b/src/utils/license-validation-lease.ts
@@ -1,0 +1,31 @@
+import { LICENSE_CLOUD_REVALIDATION_DAYS } from "../config/license-cloud-config";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface CloudValidationLeaseStatus {
+	valid: boolean;
+	needsValidation: boolean;
+}
+
+export class CloudValidationLease {
+	private lastSuccessfulValidationAt: number | null = null;
+
+	recordSuccess(now = Date.now()): void {
+		this.lastSuccessfulValidationAt = now;
+	}
+
+	clear(): void {
+		this.lastSuccessfulValidationAt = null;
+	}
+
+	getStatus(now = Date.now()): CloudValidationLeaseStatus {
+		if (this.lastSuccessfulValidationAt === null) {
+			return { valid: false, needsValidation: true };
+		}
+
+		const expiresAt =
+			this.lastSuccessfulValidationAt + LICENSE_CLOUD_REVALIDATION_DAYS * DAY_MS;
+		const valid = now < expiresAt;
+		return { valid, needsValidation: !valid };
+	}
+}

--- a/src/utils/licenseManager.ts
+++ b/src/utils/licenseManager.ts
@@ -21,10 +21,10 @@ import {
 import {
 	isCloudLicenseConfigured,
 	LICENSE_CLOUD_MAX_DEVICES,
-	LICENSE_CLOUD_REVALIDATION_DAYS,
 } from "../config/license-cloud-config";
 import { sanitizeCloudLicenseUserMessage } from "./activation-privacy";
 import { CloudLicenseValidator } from "./cloudLicenseValidator";
+import { CloudValidationLease } from "./license-validation-lease";
 import { assertSubmittedEmailMatchesActivationOwner } from "./license-owner-email";
 import {
 	DEVICE_FINGERPRINT_VERSION,
@@ -48,6 +48,7 @@ function getRuntimePlatformLabel(): string {
 export class LicenseManager {
 	// 云端验证器
 	private cloudValidator: CloudLicenseValidator;
+	private cloudValidationLease = new CloudValidationLease();
 	private app: App | null = null;
 
 	constructor() {
@@ -56,6 +57,7 @@ export class LicenseManager {
 
 	initializeCloud(app: App): void {
 		this.app = app;
+		this.cloudValidationLease.clear();
 		this.cloudValidator.setApp(app);
 		ActivationAttemptLimiter.setApp(app);
 	}
@@ -301,6 +303,8 @@ export class LicenseManager {
 				};
 			}
 
+			this.cloudValidationLease.recordSuccess();
+
 			const maxDevices = Math.min(
 				cloudResult.max_devices ?? data.maxDevices ?? LICENSE_CLOUD_MAX_DEVICES,
 				LICENSE_CLOUD_MAX_DEVICES
@@ -433,6 +437,10 @@ export class LicenseManager {
 				}
 			}
 
+			if (!normalizedLicense.boundEmail?.trim()) {
+				return { isValid: false, error: "许可证缺少绑定邮箱，请重新激活" };
+			}
+
 			// 验证时间有效性
 			const now = new Date();
 			const activatedAt = new Date(normalizedLicense.activatedAt);
@@ -478,15 +486,12 @@ export class LicenseManager {
 				);
 			}
 
-			if (normalizedLicense.boundEmail && isCloudLicenseConfigured()) {
-				const cloudCheck = await this.performCloudValidation(
-					normalizedLicense,
-					currentFingerprint,
-					warnings
-				);
-				if (!cloudCheck.ok) {
-					return { isValid: false, error: cloudCheck.error };
-				}
+			const cloudCheck = await this.performCloudValidation(
+				normalizedLicense,
+				currentFingerprint
+			);
+			if (!cloudCheck.ok) {
+				return { isValid: false, error: cloudCheck.error };
 			}
 
 			// 重新验证激活码
@@ -579,16 +584,18 @@ export class LicenseManager {
 	 */
 	private async performCloudValidation(
 		licenseInfo: LicenseInfo,
-		currentFingerprint: string,
-		warnings: string[]
+		currentFingerprint: string
 	): Promise<{ ok: boolean; error?: string }> {
 		try {
-			if (!licenseInfo.boundEmail) {
-				return { ok: true };
+			if (!licenseInfo.boundEmail?.trim()) {
+				return { ok: false, error: "许可证缺少绑定邮箱，请重新激活" };
 			}
 
-			const needsValidation = this.shouldPerformCloudValidation(licenseInfo);
-			if (!needsValidation) {
+			if (!isCloudLicenseConfigured()) {
+				return { ok: false, error: "云服务未配置，无法验证许可证" };
+			}
+
+			if (!this.cloudValidationLease.getStatus().needsValidation) {
 				return { ok: true };
 			}
 
@@ -608,13 +615,16 @@ export class LicenseManager {
 					devicesUsed: cloudResult.devices_count ?? licenseInfo.cloudSync?.devicesUsed,
 					devicesMax: cloudResult.max_devices ?? licenseInfo.cloudSync?.devicesMax ?? licenseInfo.maxDevices,
 				};
+				this.cloudValidationLease.recordSuccess();
 				return { ok: true };
 			}
 
 			if (cloudResult.is_network_error) {
 				logger.warn("许可证云端验证暂时不可用");
-				warnings.push("许可证验证暂时不可用，请稍后重试");
-				return { ok: true };
+				return {
+					ok: false,
+					error: "许可证验证暂时不可用，请恢复网络后重试",
+				};
 			}
 
 			return {
@@ -630,20 +640,6 @@ export class LicenseManager {
 				error: error instanceof Error ? error.message : "云端验证异常",
 			};
 		}
-	}
-
-	private shouldPerformCloudValidation(licenseInfo: LicenseInfo): boolean {
-		if (!isCloudLicenseConfigured() || !licenseInfo.boundEmail) {
-			return false;
-		}
-
-		if (!licenseInfo.cloudSync?.lastValidatedAt) {
-			return true;
-		}
-
-		const lastValidated = new Date(licenseInfo.cloudSync.lastValidatedAt).getTime();
-		const daysSince = (Date.now() - lastValidated) / (1000 * 60 * 60 * 24);
-		return daysSince >= LICENSE_CLOUD_REVALIDATION_DAYS;
 	}
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       'src/utils/__tests__/activation-privacy.test.ts',
       'src/utils/__tests__/plugin-license.test.ts',
       'src/utils/__tests__/license-device-stats.test.ts',
+       'src/utils/__tests__/license-validation-lease.test.ts',
       'src/utils/__tests__/device-fingerprint.test.ts',
       'src/utils/__tests__/mobile-edit-viewport.test.ts',
       'src/utils/__tests__/mobile-floating-viewport.test.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       'src/utils/__tests__/plugin-license.test.ts',
       'src/utils/__tests__/license-device-stats.test.ts',
        'src/utils/__tests__/license-validation-lease.test.ts',
+       'src/utils/__tests__/license-manager-validation.test.ts',
       'src/utils/__tests__/device-fingerprint.test.ts',
       'src/utils/__tests__/mobile-edit-viewport.test.ts',
       'src/utils/__tests__/mobile-floating-viewport.test.ts',


### PR DESCRIPTION
## 问题复现

1. 正常激活插件，使 `data.json` 中的许可证记录包含有效且未过期的 `activationCode`。
2. 保持 `isActivated` 为 `true`，删除同一许可证记录的 `boundEmail`。
3. 重新加载插件或触发既有授权刷新。
4. 修复前，缺少 `boundEmail` 会跳过云端验证，本地签名验证通过后仍会启用高级功能。

另一个相关问题是 `cloudSync.lastValidatedAt` 存储在可编辑的本地配置中。旧逻辑会将该时间作为跨重启的云验证节流依据，使修改该字段能够影响后续云验证时机。

## 修复内容

- 未激活记录保持免费态，不解析激活码、不检查到期日，也不访问云端。
- 已激活候选缺少 `boundEmail` 时强制降级，不再跳过云端验证。
- 每次插件初始化清空云验证租约；只有当前进程内成功的 `/activate` 或 `/validate` 才能建立内存租约。`data.json` 中的 `lastValidatedAt` 仅保留展示用途，不能延长授权。
- 没有有效内存租约时，云端网络错误会强制降级；租约有效时沿用现有内存授权状态，不重复发起请求。
- `hasEpubPremiumAccess()` 改为读取 `PremiumFeatureGuard` 已验证的运行时状态，不直接信任持久化许可证数据。

## 测试

- 新增内存租约测试，覆盖新实例、成功验证、过期和清空情形。
- 新增授权校验测试，覆盖未激活不联网、缺失 `boundEmail` 降级、初始化强制云验证及首次网络失败降级。
- 授权相关聚焦测试：8/8 通过。
- `npm run build`：通过。
- `npm test`：仍有 2 项既有失败，均位于 `src/services/epub/__tests__/EpubStorageService.test.ts`，与本 PR 无关：
  - `loads concealed text fragments from the legacy sync path when local artifacts are absent`
  - `can consolidate legacy epub local data into one plugin-local file and remove the legacy files`
